### PR TITLE
fix configure_optimizers func

### DIFF
--- a/src/models/model.py
+++ b/src/models/model.py
@@ -97,5 +97,5 @@ class KLUEModel(pl.LightningModule):
             )
             return [optimizer], [lr_scheduler]
         else:
-            return None
+            return optimizer
 


### PR DESCRIPTION
## ⚠️ Problem Statement

- `lr_scheduler`를 사용하지 않을 때 `optimizer`를 사용하도록 변경

## ⚗️ Experiment Setup & Results

```python3
def configure_optimizers(self):
    ...
    if self.is_scheduler:
        ...
    else:
        # return None  # 변경 전
        return optimizer # 변경 후
```