### PR TITLE
Add entity special token tagging

### DIFF
--- a/src/models/model.py
+++ b/src/models/model.py
@@ -28,7 +28,7 @@ class KLUEModel(pl.LightningModule):
         self.plm = AutoModelForSequenceClassification.from_pretrained(
             conf.model_name, config=model_config, local_files_only=True
         )
-        self.plm.resize_token_embeddings(model_config.vocab_size + 16)
+        # self.plm.resize_token_embeddings(model_config.vocab_size + 16)
         self.eval_func = eval_func
         self.criterion = nn.CrossEntropyLoss(ignore_index=-1)
         self.is_scheduler = is_scheduler

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -28,6 +28,7 @@ class KLUEModel(pl.LightningModule):
         self.plm = AutoModelForSequenceClassification.from_pretrained(
             conf.model_name, config=model_config, local_files_only=True
         )
+        self.plm.resize_token_embeddings(model_config.vocab_size + 16)
         self.eval_func = eval_func
         self.criterion = nn.CrossEntropyLoss(ignore_index=-1)
         self.is_scheduler = is_scheduler

--- a/src/utils/dataloader.py
+++ b/src/utils/dataloader.py
@@ -7,7 +7,7 @@ from torch.utils.data.dataloader import default_collate
 from sklearn.model_selection import StratifiedKFold
 from utils import *
 import pytorch_lightning as pl
-from utils.preprocessor import data_cleansing
+from utils.preprocessor import *
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -168,14 +168,17 @@ class Dataloader(pl.LightningDataModule):
 
     def tokenize_dataset(self, dataset):
         """tokenizer에 따라 sentence를 tokenizing 합니다."""
+
+        """Baseline code
         concat_entity = []
         for e01, e02 in zip(dataset["subject_entity"], dataset["object_entity"]):
             temp = ""
             temp = e01 + "[SEP]" + e02
             concat_entity.append(temp)
-
+        """
+        self.tokenizer.add_special_tokens({"additional_special_tokens": list(TYPE_TOKENS.values())})
         tokenized_sentences = self.tokenizer(
-            concat_entity,
+            # concat_entity,
             list(dataset["sentence"]),
             return_tensors="pt",
             padding=True,
@@ -189,6 +192,7 @@ class Dataloader(pl.LightningDataModule):
     def preprocessing(self, dataset):
         """처음 불러온 csv 파일을 원하는 형태의 DataFrame으로 변경 시켜줍니다."""
 
+        """Baseline code
         subject_entity = []
         object_entity = []
         for i, j in zip(dataset["subject_entity"], dataset["object_entity"]):
@@ -206,6 +210,10 @@ class Dataloader(pl.LightningDataModule):
                 "label": dataset["label"],
             }
         )
+        """
+
+        dataset = extract_entity(dataset, drop_column=True)
+        out_dataset = entity_tagging(dataset)
         tokenized_dataset = self.tokenize_dataset(out_dataset)
 
         if not self.is_test:

--- a/src/utils/dataloader.py
+++ b/src/utils/dataloader.py
@@ -79,6 +79,7 @@ class Dataloader(pl.LightningDataModule):
         self.tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name, max_length=self.max_length, local_files_only=True
         )
+        # self.tokenizer.add_special_tokens({"additional_special_tokens": list(TYPE_TOKENS.values())})
         self.batch_size = batch_size
         self.label_dict_path = label_dict_path
 
@@ -170,16 +171,16 @@ class Dataloader(pl.LightningDataModule):
     def tokenize_dataset(self, dataset):
         """tokenizer에 따라 sentence를 tokenizing 합니다."""
 
-        """Baseline code
+        # Baseline code
         concat_entity = []
         for e01, e02 in zip(dataset["subject_entity"], dataset["object_entity"]):
             temp = ""
             temp = e01 + "[SEP]" + e02
             concat_entity.append(temp)
-        """
-        self.tokenizer.add_special_tokens({"additional_special_tokens": list(TYPE_TOKENS.values())})
+        
+        
         tokenized_sentences = self.tokenizer(
-            # concat_entity,
+            concat_entity,
             list(dataset["sentence"]),
             return_tensors="pt",
             padding=True,
@@ -193,7 +194,7 @@ class Dataloader(pl.LightningDataModule):
     def preprocessing(self, dataset):
         """처음 불러온 csv 파일을 원하는 형태의 DataFrame으로 변경 시켜줍니다."""
 
-        """Baseline code
+        # Baseline code
         subject_entity = []
         object_entity = []
         for i, j in zip(dataset["subject_entity"], dataset["object_entity"]):
@@ -211,10 +212,10 @@ class Dataloader(pl.LightningDataModule):
                 "label": dataset["label"],
             }
         )
-        """
+         
 
-        dataset = extract_entity(dataset, drop_column=True)
-        out_dataset = entity_tagging(dataset)
+        # dataset = extract_entity(dataset, drop_column=True)
+        # out_dataset = entity_tagging(dataset)
         tokenized_dataset = self.tokenize_dataset(out_dataset)
 
         if not self.is_test:

--- a/unit_test/entity_special_token.ipynb
+++ b/unit_test/entity_special_token.ipynb
@@ -1,0 +1,631 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "73867b91-1a7a-4743-a5a7-d63c8bd35312",
+   "metadata": {},
+   "source": [
+    "# entity special token 전처리 결과"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8ada034f-1b24-435f-bb69-742d055f9df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle as pickle\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "from transformers import AutoTokenizer, AutoConfig, AutoModelForSequenceClassification, Trainer, TrainingArguments, RobertaConfig, RobertaTokenizer, RobertaForSequenceClassification, BertTokenizer\n",
+    "import re\n",
+    "\n",
+    "train_data = pd.read_csv(\"../../data/train/train.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ac32564-57d5-4ada-8b37-dce3e92cfecd",
+   "metadata": {},
+   "source": [
+    "## 기존 entity 분리 코드"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "921ef7f7-bbe9-4576-bb73-674b5c1c0fdf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>sentence</th>\n",
+       "      <th>label</th>\n",
+       "      <th>source</th>\n",
+       "      <th>subject_word</th>\n",
+       "      <th>subject_start_idx</th>\n",
+       "      <th>subject_end_idx</th>\n",
+       "      <th>subject_type</th>\n",
+       "      <th>object_word</th>\n",
+       "      <th>object_start_idx</th>\n",
+       "      <th>object_end_idx</th>\n",
+       "      <th>object_type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>〈Something〉는 조지 해리슨이 쓰고 비틀즈가 1969년 앨범 《Abbey R...</td>\n",
+       "      <td>no_relation</td>\n",
+       "      <td>wikipedia</td>\n",
+       "      <td>비틀즈</td>\n",
+       "      <td>24</td>\n",
+       "      <td>26</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>조지 해리슨</td>\n",
+       "      <td>13</td>\n",
+       "      <td>18</td>\n",
+       "      <td>PER</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>호남이 기반인 바른미래당·대안신당·민주평화당이 우여곡절 끝에 합당해 민생당(가칭)으...</td>\n",
+       "      <td>no_relation</td>\n",
+       "      <td>wikitree</td>\n",
+       "      <td>민주평화당</td>\n",
+       "      <td>19</td>\n",
+       "      <td>23</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>대안신당</td>\n",
+       "      <td>14</td>\n",
+       "      <td>17</td>\n",
+       "      <td>ORG</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>K리그2에서 성적 1위를 달리고 있는 광주FC는 지난 26일 한국프로축구연맹으로부터...</td>\n",
+       "      <td>org:member_of</td>\n",
+       "      <td>wikitree</td>\n",
+       "      <td>광주FC</td>\n",
+       "      <td>21</td>\n",
+       "      <td>24</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>한국프로축구연맹</td>\n",
+       "      <td>34</td>\n",
+       "      <td>41</td>\n",
+       "      <td>ORG</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>균일가 생활용품점 (주)아성다이소(대표 박정부)는 코로나19 바이러스로 어려움을 겪...</td>\n",
+       "      <td>org:top_members/employees</td>\n",
+       "      <td>wikitree</td>\n",
+       "      <td>아성다이소</td>\n",
+       "      <td>13</td>\n",
+       "      <td>17</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>박정부</td>\n",
+       "      <td>22</td>\n",
+       "      <td>24</td>\n",
+       "      <td>PER</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>1967년 프로 야구 드래프트 1순위로 요미우리 자이언츠에게 입단하면서 등번호는 8...</td>\n",
+       "      <td>no_relation</td>\n",
+       "      <td>wikipedia</td>\n",
+       "      <td>요미우리 자이언츠</td>\n",
+       "      <td>22</td>\n",
+       "      <td>30</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>1967</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>DAT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id                                           sentence  \\\n",
+       "0   0  〈Something〉는 조지 해리슨이 쓰고 비틀즈가 1969년 앨범 《Abbey R...   \n",
+       "1   1  호남이 기반인 바른미래당·대안신당·민주평화당이 우여곡절 끝에 합당해 민생당(가칭)으...   \n",
+       "2   2  K리그2에서 성적 1위를 달리고 있는 광주FC는 지난 26일 한국프로축구연맹으로부터...   \n",
+       "3   3  균일가 생활용품점 (주)아성다이소(대표 박정부)는 코로나19 바이러스로 어려움을 겪...   \n",
+       "4   4  1967년 프로 야구 드래프트 1순위로 요미우리 자이언츠에게 입단하면서 등번호는 8...   \n",
+       "\n",
+       "                       label     source subject_word  subject_start_idx  \\\n",
+       "0                no_relation  wikipedia          비틀즈                 24   \n",
+       "1                no_relation   wikitree        민주평화당                 19   \n",
+       "2              org:member_of   wikitree         광주FC                 21   \n",
+       "3  org:top_members/employees   wikitree        아성다이소                 13   \n",
+       "4                no_relation  wikipedia    요미우리 자이언츠                 22   \n",
+       "\n",
+       "   subject_end_idx subject_type object_word  object_start_idx  object_end_idx  \\\n",
+       "0               26          ORG      조지 해리슨                13              18   \n",
+       "1               23          ORG        대안신당                14              17   \n",
+       "2               24          ORG    한국프로축구연맹                34              41   \n",
+       "3               17          ORG         박정부                22              24   \n",
+       "4               30          ORG        1967                 0               3   \n",
+       "\n",
+       "  object_type  \n",
+       "0         PER  \n",
+       "1         ORG  \n",
+       "2         ORG  \n",
+       "3         PER  \n",
+       "4         DAT  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def extract_entity(\n",
+    "    input_df: pd.DataFrame, tokenizer=None, drop_column=False\n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    데이터셋 DataFrame을 입력받고, entity의 ['word', 'start_idx', 'end_idx', 'type'] 요소들을 추출하여 새 column으로 생성합니다.\n",
+    "    추가되는 새 column들은 다음과 같습니다.\n",
+    "        subject_word, subejct_start_idx, subject_end_idx, subject_type\n",
+    "        object_word, object_start_idx, object_end_idx, object_type\n",
+    "\n",
+    "    parameters\n",
+    "        tokenizer : transformers.AutoTokenizer를 입력하면 subject_word, object_word가 토큰으로 분리되어 처리됩니다.\n",
+    "        drop_column : 기존 subject_entity, object_entity column들을 drop할지 여부를 결정합니다.\n",
+    "    \"\"\"\n",
+    "    df = input_df.copy()\n",
+    "    col_list = [\"word\", \"start_idx\", \"end_idx\", \"type\"]\n",
+    "    sub_contents = [[] for _ in range(len(col_list))]\n",
+    "    obj_contents = [[] for _ in range(len(col_list))]\n",
+    "\n",
+    "    for sub_items, obj_items in zip(df[\"subject_entity\"], df[\"object_entity\"]):\n",
+    "        # 쉼표 중 앞에는 문자가 있고, 뒤에는 공백이 있으며 공백 뒤에 \\' 가 있는 쉼표를 기준으로 split합니다.\n",
+    "        sub_items = re.split(r\"(?<=\\S),\\s(?=\\')\", sub_items[1:-1])\n",
+    "        obj_items = re.split(r\"(?<=\\S),\\s(?=\\')\", obj_items[1:-1])\n",
+    "        for i, (sub_content, obj_content) in enumerate(zip(sub_items, obj_items)):\n",
+    "            # ':' 중 앞에는 \\' 가 있고, 뒤에는 공백이 있는 ':'를 기준으로 split합니다.\n",
+    "            sub_key, sub_insert = map(\n",
+    "                str.strip, re.split(r\"(?<=\\'):(?=\\s)\", sub_content)\n",
+    "            )\n",
+    "            obj_key, obj_insert = map(\n",
+    "                str.strip, re.split(r\"(?<=\\'):(?=\\s)\", obj_content)\n",
+    "            )\n",
+    "            # 문자열의 맨 처음에 위치한 \\' 와 맨 뒤에 위치한 \\'를 제거합니다.\n",
+    "            sub_insert = re.sub(\"^'|'$\", \"\", sub_insert)\n",
+    "            obj_insert = re.sub(\"^'|'$\", \"\", obj_insert)\n",
+    "            if tokenizer and sub_key == \"'word'\":\n",
+    "                sub_contents[i].append(tokenizer.tokenize(str(sub_insert)))\n",
+    "                obj_contents[i].append(tokenizer.tokenize(str(obj_insert)))\n",
+    "            else:\n",
+    "                sub_contents[i].append(sub_insert)\n",
+    "                obj_contents[i].append(obj_insert)\n",
+    "\n",
+    "    # entity의 elements들을 새 column으로 추가합니다.\n",
+    "    prefix_list = [\"subject_\", \"object_\"]\n",
+    "    for prefix, contents in zip(prefix_list, [sub_contents, obj_contents]):\n",
+    "        for col, content in zip(col_list, contents):\n",
+    "            col_name = prefix + col\n",
+    "            df[col_name] = content\n",
+    "            if \"idx\" in col_name:\n",
+    "                df[col_name] = df[col_name].astype(\"int\")\n",
+    "    if drop_column:\n",
+    "        df = df.drop([\"subject_entity\", \"object_entity\"], axis=1)\n",
+    "    return df\n",
+    "\n",
+    "dataset = extract_entity(train_data, drop_column=True)\n",
+    "dataset.head(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aad53345-6493-4e9b-b5cb-40b1300f2a73",
+   "metadata": {},
+   "source": [
+    "## entity token 전처리 코드"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17c2f373-6ee4-4ec1-ad28-73d1d6225c90",
+   "metadata": {},
+   "source": [
+    "Dataframe을 탐색할 때 iterrows로 했다가 1분이상 걸려서 numpy를 이용하여 최적화했습니다."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "712df161-d4d3-42dd-a442-06e347be1bc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 572 ms, sys: 12 ms, total: 584 ms\n",
+      "Wall time: 585 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "def entity_tagging(\n",
+    "    dataset: pd.DataFrame, \n",
+    ") -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    sentence에 entity type token을 추가하여 전처리합니다.\n",
+    "    \n",
+    "    -  〈Something〉는 <obj:PER>조지 해리슨</obj:PER>이 쓰고 <subj:ORG>비틀즈</subj:ORG>가 1969년 앨범\n",
+    "    \"\"\"\n",
+    "    df = dataset.copy()\n",
+    "    data_np = dataset.to_numpy() # numpy로 데이터 탐색\n",
+    "    data_np = np.transpose(data_np)\n",
+    "    \n",
+    "    # data_np의 인덱스입니다\n",
+    "    # 0:'id', 1:'sentence', 2:'label', 3:'source', 4:'subject_word', 5:'subject_start_idx',\n",
+    "    # 6:'subject_end_idx', 7:'subject_type', 8:'object_word', 9:'object_start_idx',\n",
+    "    # 10:'object_end_idx', 11:'object_type')\n",
+    "\n",
+    "    for i in df.index:\n",
+    "        subject_start_marker = f\"<subj:{data_np[7][i]}>\"\n",
+    "        subject_end_marker   = f\"</subj:{data_np[7][i]}>\"\n",
+    "        object_start_marker  = f\"<obj:{data_np[11][i]}>\"\n",
+    "        object_end_marker    = f\"</obj:{data_np[11][i]}>\"\n",
+    "        \n",
+    "        if \"'\" in data_np[8][i]: # (')이 포함된 문장 전처리\n",
+    "            data_np[8][i] = data_np[8][i].strip('\"')\n",
+    "            \n",
+    "        sent = data_np[1][i]\n",
+    "        \n",
+    "        if data_np[5][i] < data_np[9][i]:  # subject가 object보다 앞에 있는 겨우\n",
+    "            tmp = (sent[0:data_np[5][i]] + subject_start_marker + data_np[4][i] + subject_end_marker +\n",
+    "                   sent[data_np[6][i]+1:data_np[9][i]] + object_start_marker + data_np[8][i] + object_end_marker + sent[data_np[10][i]+1:-1])\n",
+    "            \n",
+    "            data_np[5][i] += len(subject_start_marker) # subject_start_idx\n",
+    "            data_np[6][i] += len(subject_start_marker) # subject_end_idx\n",
+    "            data_np[9][i] += len(subject_start_marker + subject_end_marker + object_start_marker) # object_start_idx\n",
+    "            data_np[10][i] += len(subject_start_marker + subject_end_marker + object_start_marker) # object_end_idx\n",
+    "            \n",
+    "        else:  # object가 subject보다 앞에 있는 경우\n",
+    "            tmp = (sent[0:data_np[9][i]] + object_start_marker + data_np[8][i] + object_end_marker +\n",
+    "                   sent[data_np[10][i]+1:data_np[5][i]] + subject_start_marker + data_np[4][i] + subject_end_marker + sent[data_np[6][i]+1:-1])\n",
+    "\n",
+    "            data_np[5][i] += len(object_start_marker + object_end_marker + subject_start_marker) # subject_start_idx\n",
+    "            data_np[6][i] += len(object_start_marker + object_end_marker + subject_start_marker) # subject_end_idx\n",
+    "            data_np[9][i] += len(object_start_marker) # object_start_idx\n",
+    "            data_np[10][i] += len(object_start_marker) # object_end_idx \n",
+    "            \n",
+    "        str_tmp = \"\".join(tmp)\n",
+    "        data_np[1][i] = str_tmp # sentence\n",
+    "        \n",
+    "    df[\"sentence\"] = data_np[1].copy()\n",
+    "    df[\"subject_start_idx\"] = data_np[5].copy()\n",
+    "    df[\"subject_end_idx\"] = data_np[6].copy()\n",
+    "    df[\"object_start_idx\"] = data_np[9].copy()\n",
+    "    df[\"object_end_idx\"] = data_np[10].copy()\n",
+    "    \n",
+    "    return df\n",
+    "\n",
+    "%time output = entity_tagging(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf043305-669a-49fd-8405-f6151effd262",
+   "metadata": {},
+   "source": [
+    "## 코드 테스트"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30773e10-09b8-4c2e-a9fb-54901e370873",
+   "metadata": {},
+   "source": [
+    "### 전처리 결과(sentence, idx 변경)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "905c3ca3-d444-436a-bc2b-18139c2ce15d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>sentence</th>\n",
+       "      <th>label</th>\n",
+       "      <th>source</th>\n",
+       "      <th>subject_word</th>\n",
+       "      <th>subject_start_idx</th>\n",
+       "      <th>subject_end_idx</th>\n",
+       "      <th>subject_type</th>\n",
+       "      <th>object_word</th>\n",
+       "      <th>object_start_idx</th>\n",
+       "      <th>object_end_idx</th>\n",
+       "      <th>object_type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>〈Something〉는 &lt;obj:PER&gt;조지 해리슨&lt;/obj:PER&gt;이 쓰고 &lt;su...</td>\n",
+       "      <td>no_relation</td>\n",
+       "      <td>wikipedia</td>\n",
+       "      <td>비틀즈</td>\n",
+       "      <td>53</td>\n",
+       "      <td>55</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>조지 해리슨</td>\n",
+       "      <td>22</td>\n",
+       "      <td>27</td>\n",
+       "      <td>PER</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>호남이 기반인 바른미래당·&lt;obj:ORG&gt;대안신당&lt;/obj:ORG&gt;·&lt;subj:OR...</td>\n",
+       "      <td>no_relation</td>\n",
+       "      <td>wikitree</td>\n",
+       "      <td>민주평화당</td>\n",
+       "      <td>48</td>\n",
+       "      <td>52</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>대안신당</td>\n",
+       "      <td>23</td>\n",
+       "      <td>26</td>\n",
+       "      <td>ORG</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>K리그2에서 성적 1위를 달리고 있는 &lt;subj:ORG&gt;광주FC&lt;/subj:ORG&gt;...</td>\n",
+       "      <td>org:member_of</td>\n",
+       "      <td>wikitree</td>\n",
+       "      <td>광주FC</td>\n",
+       "      <td>31</td>\n",
+       "      <td>34</td>\n",
+       "      <td>ORG</td>\n",
+       "      <td>한국프로축구연맹</td>\n",
+       "      <td>64</td>\n",
+       "      <td>71</td>\n",
+       "      <td>ORG</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id                                           sentence          label  \\\n",
+       "0   0  〈Something〉는 <obj:PER>조지 해리슨</obj:PER>이 쓰고 <su...    no_relation   \n",
+       "1   1  호남이 기반인 바른미래당·<obj:ORG>대안신당</obj:ORG>·<subj:OR...    no_relation   \n",
+       "2   2  K리그2에서 성적 1위를 달리고 있는 <subj:ORG>광주FC</subj:ORG>...  org:member_of   \n",
+       "\n",
+       "      source subject_word subject_start_idx subject_end_idx subject_type  \\\n",
+       "0  wikipedia          비틀즈                53              55          ORG   \n",
+       "1   wikitree        민주평화당                48              52          ORG   \n",
+       "2   wikitree         광주FC                31              34          ORG   \n",
+       "\n",
+       "  object_word object_start_idx object_end_idx object_type  \n",
+       "0      조지 해리슨               22             27         PER  \n",
+       "1        대안신당               23             26         ORG  \n",
+       "2    한국프로축구연맹               64             71         ORG  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6ba9b4e-7f63-4f14-ad6f-5713d32ccb17",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### sentence 결과"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e0516c49-3c1e-49c1-9995-0ec9e1b3129b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0                                            〈Something〉는 <obj:PER>조지 해리슨</obj:PER>이 쓰고 <subj:ORG>비틀즈</subj:ORG>가 1969년 앨범 《Abbey Road》에 담은 노래다\n",
+       "1                                                 호남이 기반인 바른미래당·<obj:ORG>대안신당</obj:ORG>·<subj:ORG>민주평화당</subj:ORG>이 우여곡절 끝에 합당해 민생당(가칭)으로 재탄생한다\n",
+       "2    K리그2에서 성적 1위를 달리고 있는 <subj:ORG>광주FC</subj:ORG>는 지난 26일 <obj:ORG>한국프로축구연맹</obj:ORG>으로부터 관중 유치 성과와 마케팅 성과를 인정받아 ‘풀 스타디움상’과 ‘플러스 스타디움상’을 수상했다\n",
+       "Name: sentence, dtype: object"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.set_option(\"max_colwidth\",300)\n",
+    "output[\"sentence\"][0:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a81610cd-d23f-4b6e-8dde-673648d7f3e0",
+   "metadata": {},
+   "source": [
+    "### 변경된 idx 확인"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85d52f59-6ca2-44a0-a61e-c4af8d9b8872",
+   "metadata": {},
+   "source": [
+    "변경된 idx를 슬라이스로 검색했습니다."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a2fa6e13-12a3-4e14-a664-813a24e54b59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(len(output)):\n",
+    "    sub_word = output[\"subject_word\"][i]\n",
+    "    ob_word = output[\"object_word\"][i].strip('\"') if \"'\" in output[\"object_word\"][i] else output[\"object_word\"][i]\n",
+    "    \n",
+    "    if sub_word != output[\"sentence\"][i][output[\"subject_start_idx\"][i]:output[\"subject_end_idx\"][i]+1]:\n",
+    "        print(\"sub_error\",\"idx :\",i)\n",
+    "    if ob_word != output[\"sentence\"][i][output[\"object_start_idx\"][i]:output[\"object_end_idx\"][i]+1]:\n",
+    "        print(\"ob_error\",\"idx :\",i)        \n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a225346a-8655-4aff-b559-25bebe5e77c3",
+   "metadata": {},
+   "source": [
+    "## tokenizer 테스트"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cb441907-6bd4-4c46-b26e-f674c862da11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['<', 'o', '##b', '##j', ':', 'PO', '##H', '>', '첼', '##리스트', '<', '/', 'o', '##b', '##j', ':', 'PO', '##H', '>', '<', 'sub', '##j', ':', 'PER', '>', '정명', '##화', '<', '/', 'sub', '##j', ':', 'PER', '>', ',', '바이올리니스트', '정경', '##화', '##의', '동생', '##이다']\n",
+      "['<obj:POH>', '첼', '##리스트', '</obj:POH>', '<subj:PER>', '정명', '##화', '</subj:PER>', ',', '바이올리니스트', '정경', '##화', '##의', '동생', '##이다']\n"
+     ]
+    }
+   ],
+   "source": [
+    "TYPE_TOKENS = dict(\n",
+    "    subject_per_start=\"<subj:PER>\",\n",
+    "    subject_org_start=\"<subj:ORG>\",\n",
+    "    subject_per_end=\"</subj:PER>\",\n",
+    "    subject_org_end=\"</subj:ORG>\",\n",
+    "    object_per_start=\"<obj:PER>\",\n",
+    "    object_org_start=\"<obj:ORG>\",\n",
+    "    object_loc_start=\"<obj:LOC>\",\n",
+    "    object_dat_start=\"<obj:DAT>\",\n",
+    "    object_poh_start=\"<obj:POH>\",\n",
+    "    object_noh_start=\"<obj:NOH>\",\n",
+    "    object_per_end=\"</obj:PER>\",\n",
+    "    object_org_end=\"</obj:ORG>\",\n",
+    "    object_loc_end=\"</obj:LOC>\",\n",
+    "    object_dat_end=\"</obj:DAT>\",\n",
+    "    object_poh_end=\"</obj:POH>\",\n",
+    "    object_noh_end=\"</obj:NOH>\",\n",
+    ")\n",
+    "\n",
+    "MODEL_NAME = \"klue/bert-base\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "print(tokenizer.tokenize(output[\"sentence\"][105])) # 기존 토크나이저\n",
+    "tokenizer.add_special_tokens({\"additional_special_tokens\": list(TYPE_TOKENS.values())})\n",
+    "print(tokenizer.tokenize(output[\"sentence\"][105])) # special tokens 추가"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1865760f-5e7a-466a-b27f-b5e0c9c7bbdb",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "special token을 추가하여 토크나이징 된 것을 확인할 수 있습니다."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.5 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d4d1e4263499bec80672ea0156c357c1ee493ec2b1c70f0acce89fc37c4a6abe"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
#17 에서 설명드린 subject와 object 앞 뒤로 entity type에 대한 special token을 추가하는 코드를 추가했습니다.

## entity_tagging function
```python
def entity_tagging(
    dataset: pd.DataFrame, 
) -> pd.DataFrame:
    """
    sentence에 entity type token을 추가하여 전처리합니다.
    -  〈Something〉는 <obj:PER>조지 해리슨</obj:PER>이 쓰고 <subj:ORG>비틀즈</subj:ORG>가 1969년 앨범
    """
    df = dataset.copy()
    data_np = dataset.to_numpy() # numpy로 데이터 탐색
    data_np = np.transpose(data_np)
    
    # data_np의 인덱스입니다
    # 0:'id', 1:'sentence', 2:'label', 3:'source', 4:'subject_word', 5:'subject_start_idx',
    # 6:'subject_end_idx', 7:'subject_type', 8:'object_word', 9:'object_start_idx',
    # 10:'object_end_idx', 11:'object_type')

    for i in df.index:
        subject_start_marker = f"<subj:{data_np[7][i]}>"
        subject_end_marker   = f"</subj:{data_np[7][i]}>"
        object_start_marker  = f"<obj:{data_np[11][i]}>"
        object_end_marker    = f"</obj:{data_np[11][i]}>"
        
        if "'" in data_np[8][i]: # (')이 포함된 문장 전처리
            data_np[8][i] = data_np[8][i].strip('"')
            
        sent = data_np[1][i]
        
        if data_np[5][i] < data_np[9][i]:  # subject가 object보다 앞에 있는 겨우
            tmp = (sent[0:data_np[5][i]] + subject_start_marker + data_np[4][i] + subject_end_marker +
                   sent[data_np[6][i]+1:data_np[9][i]] + object_start_marker + data_np[8][i] + object_end_marker + sent[data_np[10][i]+1:-1])
            
            data_np[5][i] += len(subject_start_marker) # subject_start_idx
            data_np[6][i] += len(subject_start_marker) # subject_end_idx
            data_np[9][i] += len(subject_start_marker + subject_end_marker + object_start_marker) # object_start_idx
            data_np[10][i] += len(subject_start_marker + subject_end_marker + object_start_marker) # object_end_idx
            
        else:  # object가 subject보다 앞에 있는 경우
            tmp = (sent[0:data_np[9][i]] + object_start_marker + data_np[8][i] + object_end_marker +
                   sent[data_np[10][i]+1:data_np[5][i]] + subject_start_marker + data_np[4][i] + subject_end_marker + sent[data_np[6][i]+1:-1])

            data_np[5][i] += len(object_start_marker + object_end_marker + subject_start_marker) # subject_start_idx
            data_np[6][i] += len(object_start_marker + object_end_marker + subject_start_marker) # subject_end_idx
            data_np[9][i] += len(object_start_marker) # object_start_idx
            data_np[10][i] += len(object_start_marker) # object_end_idx 
            
        str_tmp = "".join(tmp)
        data_np[1][i] = str_tmp # sentence
        
    df["sentence"] = data_np[1]
    df["subject_start_idx"] = data_np[5]
    df["subject_end_idx"] = data_np[6]
    df["object_start_idx"] = data_np[9]
    df["object_end_idx"] = data_np[10]

    return df
```
- 기존 extract_entity 함수로 entity를 나눈 데이터를 입력으로 넣는다는 전제로 작성한 코드입니다.

## 수정사항
### preprocessor.py
- special token을 정의한 변수와 entity tagging 함수를 추가했습니다.

### dataloader.py
- 베이스라인 코드와 다른 방법으로 tokenizing에 넣기 때문에 기존 코드를 주석처리하고 추가했습니다.
- tokenizer에 정의해둔 special token을 add_special_tokens로 추가했습니다.

### model.py

- AutoModelForSequenceClassification로 pretrained 모델을 불러온 후 vocabsize를 추가된 special token만큼 늘려줬습니다.

## ⚗️ Experiment Setup & Results
### 학습 결과
![image](https://user-images.githubusercontent.com/69241185/204283257-904acd94-88de-4cb1-b46a-3e8dbedbaac0.png)
- 동일한 모델과 하이퍼 파라미터로 진행했습니다.
>klue_bert-base / epoch 5 / batch-size 32 /  learning rate 1e-5

### 리더보드 결과

ver | micro_f1 | auprc
-- | -- | --
base | 62.3310 | 65.0083
add entity token | 64.6377 | 67.3484

- 리더보드 score에 소폭 상향이 있었습니다.

## 추가 의견
- entity type을 tagging하는 방법은 label에 대해 정해진 type이 있기 때문에 효과를 볼 수 있는데 학습 데이터 자체가 잘못 기입되어 있는 경우가 많았습니다. data 오기입을 수정할수록 성능향상을 기대할 수 있습니다.
- preprocessing 과정에서 기존 코드를 지우고 덮어썼는데 arg로 받아서 기능을 따로 분리해볼 수 있습니다.










